### PR TITLE
🐛 Fix webhook certificate 

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -32,7 +32,10 @@ async def set_webhook(bot: Bot):
         return
 
     certificate = None
-    if settings.TG_WEBHOOK_CERTIFICATE is not None:
+    if (
+        settings.TG_WEBHOOK_CERTIFICATE is not None
+        or settings.TG_WEBHOOK_CERTIFICATE != ""
+    ):
         certificate = BufferedInputFile(
             bytes(settings.TG_WEBHOOK_CERTIFICATE, "utf-8"), "cert.pem"
         )

--- a/app/router.py
+++ b/app/router.py
@@ -1,4 +1,4 @@
-from aiogram.types import Update
+from aiogram.types import Update, WebhookInfo
 from fastapi import APIRouter, Depends
 from typing_extensions import Annotated
 
@@ -22,3 +22,8 @@ async def webhook(
     bot: Annotated[Bot, Depends(get_bot)],
 ):
     await dispatcher.feed_update(bot=bot, update=update)
+
+
+@router.get("/bot_webhook_info")
+async def bot_webhook_info(bot: Annotated[Bot, Depends(get_bot)]) -> WebhookInfo:
+    return await bot.get_webhook_info()


### PR DESCRIPTION
:bug: Exception comes when bot trying to set webhook and certificate is empty string
Also other endpoints should work correctly, even with skipped webhook
:sparkles: Added endpoint to check current bot webhook